### PR TITLE
Bump odict from 2.5.0 to 2.7.0 & small changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -203,7 +203,7 @@ checksum = "efb7846e0cb180355c2dec69e721edafa36919850f1a9f52ffba4ebc0393cb71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -252,7 +252,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -264,7 +264,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -385,12 +385,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -403,7 +427,18 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core 0.14.4",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -412,9 +447,9 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -456,7 +491,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -577,7 +612,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -913,7 +948,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -974,7 +1009,7 @@ checksum = "6c38228f24186d9cc68c729accb4d413be9eaed6ad07ff79e0270d9e56f3de13"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1104,7 +1139,7 @@ checksum = "734799cf91479720b2f970c61a22850940dd91e27d4f02b1c6fc792778df2459"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1141,23 +1176,23 @@ dependencies = [
 
 [[package]]
 name = "odict"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e6c13b6f155fcc3536328e8a4b28ad579788cda6aa24e77b8c5bf6e9751869"
+checksum = "8c6d5ab9711b36e1325df093d27eeabb7e55c30fdb12055e76c3d7f147ffa86d"
 dependencies = [
  "brotli",
  "byteorder",
  "dirs",
  "quick-xml",
  "rayon",
- "regex",
  "rkyv",
  "sea-query",
  "serde",
  "serde_json",
+ "structural-convert",
  "thiserror",
+ "url",
  "uuid",
- "validation",
 ]
 
 [[package]]
@@ -1189,7 +1224,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1304,7 +1339,7 @@ checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1581,7 +1616,7 @@ checksum = "246b40ac189af6c675d124b802e8ef6d5246c53e17367ce9501f8f66a81abb7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1685,11 +1720,11 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "thiserror",
 ]
 
@@ -1733,7 +1768,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1825,15 +1860,53 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structural-convert"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c8b1faa3959a2aa326258e7ce07e28e0342f0c17d1d6ad092ddaa7057219d6"
+dependencies = [
+ "structural-convert-derive",
+]
+
+[[package]]
+name = "structural-convert-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5b3e4f58827163c8e46f249d87f48e508ffedd04cf4f03f2cbf115761c9d99"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1863,7 +1936,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1927,7 +2000,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1981,7 +2054,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2141,14 +2214,8 @@ checksum = "72dcd78c4f979627a754f5522cea6e6a25e55139056535fe6e69c506cd64a862"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
-
-[[package]]
-name = "validation"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb8044f0b8a3e94bc8cd089c6a2e42e435553093800b76762418d4bbc3289cc"
 
 [[package]]
 name = "vcpkg"
@@ -2208,7 +2275,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -2243,7 +2310,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2534,7 +2601,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -2555,7 +2622,7 @@ checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2575,7 +2642,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -2604,5 +2671,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.100",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ console = "0.15.11"
 flate2 = "1.0.28"
 indicatif = "0.17.11"
 map-macro = "0.3.0"
-odict = "2.5.0"
+odict = "2.7.0"
 rayon = "1.10.0"
 regex = "1.10.3"
 reqwest = { version = "0.12.15", features = ["stream"] }

--- a/src/processors/cedict/converter.rs
+++ b/src/processors/cedict/converter.rs
@@ -13,7 +13,12 @@ pub struct CEDictConverter {}
 impl Converter for CEDictConverter {
     type Entry = CEDictEntry;
 
-    fn convert(&mut self, term: &Term, data: &Vec<CEDictEntry>) -> anyhow::Result<Dictionary> {
+    fn convert(
+        &mut self,
+        term: &Term,
+        data: &Vec<CEDictEntry>,
+        _language: Option<String>,
+    ) -> anyhow::Result<Dictionary> {
         term.write_line("🔄 Converting the dictionary...")?;
 
         let progress = indicatif::ProgressBar::new(data.len() as u64);

--- a/src/processors/cedict/converter.rs
+++ b/src/processors/cedict/converter.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 
 use console::Term;
 use map_macro::hash_map;
-use odict::{Definition, DefinitionType, Dictionary, Entry, Etymology, ID, PartOfSpeech, Sense};
+use odict::{
+    Definition, DefinitionType, Dictionary, Entry, Etymology, ID, PartOfSpeech, Pronunciation,
+    PronunciationKind, Sense,
+};
 
 use crate::{processors::traits::Converter, progress::STYLE_PROGRESS};
 
@@ -32,7 +35,11 @@ impl Converter for CEDictConverter {
 
             let simplified = cedict_entry.simplified.clone();
             let traditional = cedict_entry.traditional.clone();
-            let pronunciation = cedict_entry.pronunciation.clone();
+            let pronunciation = Pronunciation {
+                kind: PronunciationKind::Pinyin,
+                value: cedict_entry.pronunciation.clone(),
+                media: Vec::new(),
+            };
 
             // Create forms for traditional characters if different from simplified
             let mut forms = vec![];
@@ -61,25 +68,29 @@ impl Converter for CEDictConverter {
             let sense = Sense {
                 pos: PartOfSpeech::n, // Default to noun as most entries are nouns
                 definitions,
+                lemma: None,
+                tags: Vec::new(),
+                translations: Vec::new(),
+                forms,
             };
 
             // Create etymology with pronunciation
             let ety = Etymology {
                 id: None,
-                pronunciation: Some(pronunciation),
                 description: None,
                 senses: hash_map! {
                     PartOfSpeech::n => sense,
                 },
+                pronunciations: vec![pronunciation],
             };
 
             // Add entry
             let entry = Entry {
-                etymologies: vec![ety],
                 term: simplified.clone(),
-                forms,
-                lemma: None,
+                rank: None,
+                etymologies: vec![ety],
                 see_also: None,
+                media: Vec::new(),
             };
 
             entries.insert(simplified, entry);

--- a/src/processors/traits.rs
+++ b/src/processors/traits.rs
@@ -102,7 +102,12 @@ pub trait Converter {
     where
         Self: Sized;
 
-    fn convert(&mut self, term: &Term, data: &Vec<Self::Entry>) -> anyhow::Result<Dictionary>;
+    fn convert(
+        &mut self,
+        term: &Term,
+        data: &Vec<Self::Entry>,
+        language: Option<String>,
+    ) -> anyhow::Result<Dictionary>;
 }
 
 pub trait Processor {
@@ -117,13 +122,13 @@ pub trait Processor {
         Self: Sized;
 
     async fn process(&self, term: &Term, language: Option<String>) -> anyhow::Result<Dictionary> {
-        let downloader = Self::Downloader::new(language)?;
+        let downloader = Self::Downloader::new(language.clone())?;
         let extractor = Self::Extractor::new()?;
         let mut converter = Self::Converter::new()?;
 
         let data = downloader.download(term).await?;
         let parsed = extractor.extract(term, &data)?;
-        let dictionary = converter.convert(term, &parsed)?;
+        let dictionary = converter.convert(term, &parsed, language)?;
 
         Ok(dictionary)
     }

--- a/src/processors/traits.rs
+++ b/src/processors/traits.rs
@@ -56,7 +56,14 @@ pub trait Downloader {
 
         let total_size = response.content_length().unwrap_or(0);
 
-        term.write_line(format!("⬇️ Downloading the dictionary from {}...", url).as_str())?;
+        term.write_line(
+            format!(
+                "⬇️ Downloading the dictionary from {} to {}...",
+                url,
+                file_path.display()
+            )
+            .as_str(),
+        )?;
 
         let pb = indicatif::ProgressBar::new(total_size);
 

--- a/src/processors/wiktionary/converter.rs
+++ b/src/processors/wiktionary/converter.rs
@@ -8,7 +8,7 @@ use odict::{
     PartOfSpeech, Sense,
 };
 
-use super::{consts::POS_MAP, schema::WiktionaryEntry};
+use super::{SUPPORTED_LANGUAGES, consts::POS_MAP, schema::WiktionaryEntry};
 
 pub struct WiktionaryConverter {
     missing_pos: Vec<String>,
@@ -37,7 +37,12 @@ impl WiktionaryConverter {
 impl Converter for WiktionaryConverter {
     type Entry = WiktionaryEntry;
 
-    fn convert(&mut self, term: &Term, data: &Vec<WiktionaryEntry>) -> anyhow::Result<Dictionary> {
+    fn convert(
+        &mut self,
+        term: &Term,
+        data: &Vec<WiktionaryEntry>,
+        language: Option<String>,
+    ) -> anyhow::Result<Dictionary> {
         term.write_line("🔄 Converting the dictionary...")?;
 
         self.missing_pos = vec![];
@@ -158,7 +163,7 @@ impl Converter for WiktionaryConverter {
 
         Ok(Dictionary {
             id: ID::new(),
-            name: None,
+            name: language.map(|lang| format!("{} Wiktionary", SUPPORTED_LANGUAGES[lang.as_str()])),
             entries,
         })
     }

--- a/src/processors/wiktionary/schema.rs
+++ b/src/processors/wiktionary/schema.rs
@@ -68,7 +68,7 @@ pub struct WiktionaryEntry {
     pub coordinate_terms: Vec<WordLink>,
     /// Non-disambiguated Wikidata identifier
     #[serde(default)]
-    pub wikidata: Option<String>,
+    pub wikidata: Vec<String>,
     /// Non-disambiguated Wikipedia page title
     #[serde(default)]
     pub wikipedia: Option<Vec<String>>,
@@ -222,7 +222,8 @@ pub struct Translation {
     #[serde(default)]
     pub alt: Option<String>,
     /// Wiktionary language code
-    pub code: String,
+    #[serde(default)]
+    pub code: Option<String>,
     /// English text clarifying the target sense
     #[serde(default)]
     pub english: Option<String>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,7 +21,7 @@ pub fn save_dictionary(
     }
 
     spinner.enable_steady_tick(Duration::from_millis(100));
-    spinner.set_message("Writing the dictionary to file (this might take awhile)...");
+    spinner.set_message("Writing the dictionary to file (this might take a while)...");
 
     writer.write_to_path(&dictionary, &output_path).unwrap();
 


### PR DESCRIPTION
Tested on Wiktionay eng, cmn, jpn and CEDict. These are all small changes, so I combine them in a single PR.

Only 86999ae52da72ce41c833957e3e9deb860b348e6 breaks API, I add a language argument to make Wiktionary name.