### PR TITLE
fix: create parent directory before saving download to file

### DIFF
--- a/src/frequency/frequency_map.rs
+++ b/src/frequency/frequency_map.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf};
 use console::Term;
 use isolang::Language;
 
-use crate::utils::{decompress_gzip, download_with_progress, hash_url, read_file, write_file};
+use crate::utils::{decompress_gzip, download_with_progress, hash_url, read_file};
 
 pub struct FrequencyMap {
     map: HashMap<String, u32>,
@@ -51,8 +51,6 @@ impl FrequencyMap {
 
                     term.clear_line()?;
                     term.write_line("✅ Download complete")?;
-
-                    write_file(&file_path, &content)?;
 
                     content
                 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,9 +68,7 @@ pub async fn download_with_progress(url: &str, output_path: &PathBuf) -> anyhow:
     pb.finish_and_clear();
 
     // Cache the downloaded content
-    let mut file = File::create(&output_path)?;
-
-    file.write_all(&content)?;
+    write_file(output_path, &content)?;
 
     Ok(content)
 }


### PR DESCRIPTION
Also delete a line which write freqency map twice.

Otherwise, if `.data/` is not existed, download would fail.