### PR TITLE
Fix Wiktionary schema

### DIFF
--- a/src/processors/wiktionary/schema.rs
+++ b/src/processors/wiktionary/schema.rs
@@ -68,7 +68,7 @@ pub struct WiktionaryEntry {
     pub coordinate_terms: Vec<WordLink>,
     /// Non-disambiguated Wikidata identifier
     #[serde(default)]
-    pub wikidata: Option<String>,
+    pub wikidata: Vec<String>,
     /// Non-disambiguated Wikipedia page title
     #[serde(default)]
     pub wikipedia: Option<Vec<String>>,
@@ -224,7 +224,8 @@ pub struct Translation {
     #[serde(default)]
     pub alt: Option<String>,
     /// Wiktionary language code
-    pub code: String,
+    #[serde(default)]
+    pub code: Option<String>,
     /// English text clarifying the target sense
     #[serde(default)]
     pub english: Option<String>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,7 +26,7 @@ pub fn save_dictionary(
     }
 
     spinner.enable_steady_tick(Duration::from_millis(100));
-    spinner.set_message("Writing the dictionary to file (this might take awhile)...");
+    spinner.set_message("Writing the dictionary to file (this might take a while)...");
 
     writer.write_to_path(&dictionary, &output_path).unwrap();
 


### PR DESCRIPTION
I cannot convert Wiktionary before, after updating the schema, it works fine.

This also fix a typo.
